### PR TITLE
fix: Make user_args a table

### DIFF
--- a/lua/luasnip_snippets/snippets/all.lua
+++ b/lua/luasnip_snippets/snippets/all.lua
@@ -45,7 +45,7 @@ return {
 	    -- value of an insert_node.
 	    s("novel", {
 	        t("It was a dark and stormy night on "),
-	        d(1, utils.date_input, {}, { user_args = "%A, %B %d of %Y" }),
+	        d(1, utils.date_input, {}, { user_args = { "%A, %B %d of %Y" } }),
 	        t(" and the clocks were striking thirteen."),
 	    }),
 

--- a/lua/luasnip_snippets/snippets/python.lua
+++ b/lua/luasnip_snippets/snippets/python.lua
@@ -66,7 +66,7 @@ return {
             t({ 'def init(self,' }),
             i(3),
             t({ '):', '\t\t' }),
-            d(4, pycdoc, { 3 }, { user_args = 2 }),
+            d(4, pycdoc, { 3 }, { user_args = { 2 } }),
             f(function(args)
                 if not args[1][1] or args[1][1] == '' then
                     return { '' }
@@ -91,7 +91,7 @@ return {
             t('('),
             i(2),
             t({ '):', '\t' }),
-            d(3, pyfdoc, { 2 }, { user_args = 1 }),
+            d(3, pyfdoc, { 2 }, { user_args = { 1 } }),
         }),
     }
 }

--- a/lua/luasnip_snippets/snippets/test.lua
+++ b/lua/luasnip_snippets/snippets/test.lua
@@ -97,7 +97,7 @@ return {
         -- )
 	    s("test dynamic", {
 	        t("AAA "),
-	        d(1, utils.date_input, {}, { user_args = "%A, %B %d of %Y" }),
+	        d(1, utils.date_input, {}, { user_args = { "%A, %B %d of %Y" } }),
 	        t(" BBB "),
 	        i(2, "second"),
 	        t(". "),
@@ -147,7 +147,7 @@ return {
         s("trig", {
 	        i(1, "1"),
 	        -- pos, function, argnodes, user_arg1
-	        d(2, lines, {1}, { user_args = "Sample Text" })
+	        d(2, lines, {1}, { user_args = { "Sample Text" } })
         }),
 
 


### PR DESCRIPTION
PR #1 contained a partial fix to [this breaking change](https://github.com/L3MON4D3/LuaSnip/issues/81#issuecomment-1064891636) in LuaSnip, but seems to have missed the fact that `user_args` itself needs to be a table. This change fixes that.